### PR TITLE
Add timestamp to snapshot delete

### DIFF
--- a/snapshot.sh
+++ b/snapshot.sh
@@ -78,9 +78,9 @@ echo "${SNAPSHOT_LIST}" | while read line ; do
    SNAPSHOT_EXPIRY="$(date -d "-${OLDER_THAN} days" +"%Y%m%d")"
 
    # check if the snapshot is older than expiry date
-if [ $SNAPSHOT_EXPIRY -ge $SNAPSHOT_DATETIME ];
-        then
-	 # delete the snapshot
-         echo "$(gcloud compute snapshots delete ${SNAPSHOT_NAME} --quiet)"
-   fi
+    if [ $SNAPSHOT_EXPIRY -ge $SNAPSHOT_DATETIME ];then
+      # delete the snapshot
+      echo -e "[$(date -Iseconds)] \c"
+      echo "$(gcloud compute snapshots delete ${SNAPSHOT_NAME})"
+    fi
 done


### PR DESCRIPTION
Also, turn off the '--quiet' option since the suggested implementation sets up logging (thus the timestamp), so why have a delete event be quiet?