### PR TITLE
Issue #34 - Fixing regex for getDeviceList

### DIFF
--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -100,7 +100,7 @@ getInstanceZone()
 
 getDeviceList()
 {
-    echo "$(gcloud compute disks list --filter users~$1 --format='value(name)')"
+    echo "$(gcloud compute disks list --filter users~$1\$ --format='value(name)')"
 }
 
 


### PR DESCRIPTION
Old regex was including other instances with names that include the current instance's name