### PR TITLE
Enable backups for foreign instances

### DIFF
--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -109,7 +109,11 @@ getInstanceName()
 
 getInstanceId()
 {
-    echo -e "$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google")"
+    if [[ -z "$OPT_INSTANCE_NAME" ]];then    # no typo: only when querying for the calling machine get the real instance ID
+        echo -e "$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google")"
+    else
+        echo $(echo $INSTANCE_NAME | md5 | cut -d' ' -f1)
+    fi
 }
 
 
@@ -302,8 +306,7 @@ createSnapshotWrapper()
     INSTANCE_NAME=$(getInstanceName)
 
     # get the device id
-    # INSTANCE_ID=$(getInstanceId)
-    INSTANCE_ID="$(echo $INSTANCE_NAME | md5sum | cut -d' ' -f1)"
+    INSTANCE_ID=$(getInstanceId)
 
     # get the instance zone
     INSTANCE_ZONE=$(getInstanceZone)

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -112,7 +112,7 @@ getInstanceId()
     if [[ -z "$OPT_INSTANCE_NAME" ]];then    # no typo: only when querying for the calling machine get the real instance ID
         echo -e "$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google")"
     else
-        echo $(echo $INSTANCE_NAME | md5 | cut -d' ' -f1)
+        echo $(echo $INSTANCE_NAME | md5sum | cut -d' ' -f1)
     fi
 }
 


### PR DESCRIPTION
This PR adds two parameters to enable making snapshots for instances other than the calling instance. I don't feel quite comfortable that the running instance has permission to delete its own snapshots. We already had the case where a hacker entered a machine and not only deleted everything on the local disks, but also the backups that were reachable from that host. I therefore like to make a dedicated snapshotting instance which has the required permissions, whereas the other instances that are exposed to the Internet don't have the rights to create or delete snapshots.

The PR here allows to specify the name of another instance to make snapshots for. Since it's not possible to query the instance ID or instance zone of a foreign instance using the metadata API, we can also pass the instance zone as parameter. _Note regarding the instance ID_: since the instance ID is only used for cosmetic purposes it seems, and to avoid having to add yet another parameter, I replaced the instanced ID with the MD5 hash of the instance name when called for a foreign instance. For the same instance (previous behaviour) the instance ID is fetched from the metadata API, so there should be no breaking changes for existing backups and existing usages of this script.