### PR TITLE
Add support to use a specific service account via command line

### DIFF
--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -19,7 +19,7 @@ export PATH=$PATH:/usr/local/bin/:/usr/bin
 #
 
 usage() {
-    echo -e "\nUsage: $0 [-d <days>] [-t <label_name>] [-i <instance_name>] [-z <instance_zone>] [-p <prefix>]" 1>&2
+    echo -e "\nUsage: $0 [-d <days>] [-t <label_name>] [-i <instance_name>] [-z <instance_zone>] [-p <prefix>] [-a <service_account>]" 1>&2
     echo -e "\nOptions:\n"
     echo -e "    -d    Number of days to keep snapshots.  Snapshots older than this number deleted."
     echo -e "          Default if not set: 7 [OPTIONAL]"

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -28,6 +28,7 @@ usage() {
     echo -e "          host."
     echo -e "    -z    Instance zone. If empty, uses the zone of the calling host."
     echo -e "    -p    Prefix to be used for naming snapshots, default to 'gcs'"
+    echo -e "    -a    Service Account to use. If empty, it uses the gcloud default."
     echo -e "\n"
     exit 1
 }
@@ -55,6 +56,8 @@ setScriptOptions()
                 ;;
             p)
                 opt_p=${OPTARG}
+                ;;
+            a)  opt_a=${OPTARG}
                 ;;
             *)
                 usage
@@ -92,6 +95,12 @@ setScriptOptions()
     else
         PREFIX="gcs"
     fi
+
+    if [[ -n $opt_a ]];then
+        OPT_INSTANCE_SERVICE_ACCOUNT="--account $opt_a"
+    else
+        OPT_INSTANCE_SERVICE_ACCOUNT=""
+    fi
 }
 
 
@@ -122,7 +131,7 @@ getInstanceId()
     if [[ -z "$OPT_INSTANCE_NAME" ]];then    # no typo: only when querying for the calling machine get the real instance ID
         echo -e "$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google")"
     else
-        echo -e "$(gcloud -q compute instances describe $OPT_INSTANCE_NAME --zone=$INSTANCE_ZONE --format='value(id)')"
+        echo -e "$(gcloud $OPT_INSTANCE_SERVICE_ACCOUNT -q compute instances describe $OPT_INSTANCE_NAME --zone=$INSTANCE_ZONE --format='value(id)')"
     fi
 }
 
@@ -152,7 +161,7 @@ getInstanceZone()
 
 getDeviceList()
 {
-    echo -e "$(gcloud compute disks list --filter "users~instances/$1\$ $LABEL_CLAUSE" --format='value(name)')"
+    echo -e "$(gcloud $OPT_INSTANCE_SERVICE_ACCOUNT compute disks list --filter "users~instances/$1\$ $LABEL_CLAUSE" --format='value(name)')"
 }
 
 
@@ -197,7 +206,7 @@ createSnapshotName()
 
 createSnapshot()
 {
-    echo -e "$(gcloud compute disks snapshot $1 --snapshot-names $2 --zone $3)"
+    echo -e "$(gcloud $OPT_INSTANCE_SERVICE_ACCOUNT compute disks snapshot $1 --snapshot-names $2 --zone $3)"
 }
 
 
@@ -214,7 +223,7 @@ getSnapshotsForDeletion()
     SNAPSHOTS=()
 
     # get list of snapshots from gcloud for this device
-    local gcloud_response="$(gcloud compute snapshots list --filter="name~'"$1"' AND creationTimestamp<'$2'" --uri)"
+    local gcloud_response="$(gcloud $OPT_INSTANCE_SERVICE_ACCOUNT compute snapshots list --filter="name~'"$1"' AND creationTimestamp<'$2'" --uri)"
 
     # loop through and get snapshot name from URI
     while read line
@@ -249,7 +258,7 @@ getSnapshotDeletionDate()
 
 deleteSnapshot()
 {
-    echo -e "$(gcloud compute snapshots delete $1 -q)"
+    echo -e "$(gcloud $OPT_INSTANCE_SERVICE_ACCOUNT compute snapshots delete $1 -q)"
 }
 
 

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -40,7 +40,7 @@ usage() {
 
 setScriptOptions()
 {
-    while getopts ":d:t:i:z:p:" o; do
+    while getopts ":d:t:i:z:p:a:" o; do
         case "${o}" in
             d)
                 opt_d=${OPTARG}
@@ -57,7 +57,8 @@ setScriptOptions()
             p)
                 opt_p=${OPTARG}
                 ;;
-            a)  opt_a=${OPTARG}
+            a)  
+                opt_a=${OPTARG}
                 ;;
             *)
                 usage


### PR DESCRIPTION
In some environments, GCE instances are running with a "read-only" service account as default or with multiple service accounts

With this PR I'll add the ability to choose one of the existing service account to use for snapshots, so that there is no need to change the machine default service account, like the following:

```
# gcloud auth list
                      Credentialed Accounts
ACTIVE  ACCOUNT
        snapshotserviceaccount@xxxxxxxx.iam.gserviceaccount.com
        anotherserviceaccount@xxxxxxxx.iam.gserviceaccount.com
*       defaultserviceaccount@xxxxxxxx.iam.gserviceaccount.com

To set the active account, run:
    $ gcloud config set account `ACCOUNT`

```

GCE instance is running with default service account, but as I have multiple service account registered, by using the `-a` flag i'm able to choose the proper service account for snapshots