### PR TITLE
flexible filter for choosing disk to snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ Example: If you set the label to "auto_snapshot", only disks matching this key/v
 
     auto_snapshot=true
 
+Use -T for a more flexible way to specify the disks to snapshot.
+    Usage: ./gcloud-compute-snapshot.sh [-T <gcloud_filter_expression>]
+
+    Options:
+
+       -T    Only back up disks returned from querying with this filter. Uses gcloud filter expressions"
+             If both -t and -T are used, both terms are joined by the operator AND"
+
+Example: ./gcloud-compute-snapshot.sh -t auto_snapshot -T "sizeGb = 10 AND name: ubuntu". Attached disks matching this expression will be snapshotted
+
+    --format="labels.auto_snapshot=true AND sizeGb = 10 AND name: ubuntu"
+
 This also allows you to bake snapshotting into your Google images by setting a cron job with a label on every image you create, and then you can set a label on the volumes you want to
 snapshot in your infrastructure management tool (Terraform) to selectively snapshot them.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Use -T for a more flexible way to specify the disks to snapshot.
        -T    Only back up disks returned from querying with this filter. Uses gcloud filter expressions"
              If both -t and -T are used, both terms are joined by the operator AND"
 
-Example: ./gcloud-compute-snapshot.sh -t auto_snapshot -T "sizeGb = 10 AND name: ubuntu". Attached disks matching this expression will be snapshotted
+Example: `./gcloud-compute-snapshot.sh -t auto_snapshot -T "sizeGb = 10 AND name: ubuntu"`. Attached disks matching this expression will be snapshotted
 
     --format="labels.auto_snapshot=true AND sizeGb = 10 AND name: ubuntu"
 

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -81,7 +81,7 @@ setScriptOptions()
     fi
 
     if [[ -n $opt_T ]];then
-        LABEL_CLAUSE="$LABEL_CLAUSE AND $opt_T"
+        FILTER_CLAUSE="$LABEL_CLAUSE AND $opt_T"
     fi
 
     if [[ -n $opt_i ]];then
@@ -161,7 +161,7 @@ getInstanceZone()
 
 getDeviceList()
 {
-    echo -e "$(gcloud compute disks list --filter "users~instances/$1\$ $LABEL_CLAUSE" --format='value(name)')"
+    echo -e "$(gcloud compute disks list --filter "users~instances/$1\$ $FILTER_CLAUSE" --format='value(name)')"
 }
 
 


### PR DESCRIPTION
The current API only allows `labels.xyz = true`

The motivation to make this more flexible is so that there is no change needed to the disks to adopt this script. 

Furthermore, the underlying gcloud API already supports a more powerful filter expression, don't see any reason not to use it. 