### PR TITLE
Update readme and snapshot matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo nano /etc/logrotate.d/cron
 ## Snapshot Retention
 By default snapshots will be kept for 7 days, however they can be kept for longer / shorter, by using the the -d flag:
 
-    Usage: ./snapshot.sh [-d <days>]
+    Usage: ./gcloud-snapshot.sh [-d <days>]
     
     Options:
     
@@ -91,7 +91,7 @@ By default snapshots will be kept for 7 days, however they can be kept for longe
 ## Matching on specific disks
 By default, snapshots will be created for all attached disks.  To only snapshot specific disks (ie. data volumes while skipping boot volumes), use the -t flag:
 
-    Usage: ./snapshot.sh [-t <label>]
+    Usage: ./gcloud-snapshot.sh [-t <label>]
     
     Options:
     

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -86,6 +86,8 @@ setScriptOptions()
 
     if [[ -n $opt_T ]];then
         FILTER_CLAUSE="$LABEL_CLAUSE AND $opt_T"
+    else
+        FILTER_CLAUSE=$LABEL_CLAUSE
     fi
 
     if [[ -n $opt_i ]];then


### PR DESCRIPTION
- Corrected file name in readme from snapshot.sh to gcloud-snapshot.sh
- For the current case, if there's only `-t` specified without `-T`, $FILTER_CLAUSE will become null, result in snapshot matching failure