### PR TITLE
add project id option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Options:
           Default if not set: 'gcs' [OPTIONAL]
     -a    Service Account to use. 
           Blank if not set [OPTIONAL]
+    -j    Project ID to use.
+          Blank if not set [OPTIONAL]
     -n    Dry run: causes script to print debug variables and doesn't execute any 
           create / delete commands [OPTIONAL]
 ```
@@ -153,6 +155,20 @@ By default snapshots are created with the default gcloud service account. To use
 For example:
 
     ./gcloud-snapshot.sh -a "my-service-account@test9q.iam.gserviceaccount.com"
+
+### Project ID
+By default snapshots are created with the default gcloud project id. To use a custom project id use the -j flag:
+
+    Usage: ./gcloud-snapshot.sh [-j <project_id>]
+    
+    Options:
+    
+       -j  Project ID to use.
+           Blank if not set [OPTIONAL]
+
+For example:
+
+    ./gcloud-snapshot.sh -j "my-test-project"
 
 ### Dry Run
 The script can be run in dry run mode, which doesn't execute any create / delete commands, and prints out debug information.


### PR DESCRIPTION
Added a project id option `-j` so that the script can be run to backup multiple projects without needing to change the gcloud config core.project each time.  Here's an example of how we'll be using the feature.

```
gcloud-snapshot.sh -r -j project1 -f labels.backup=true
gcloud-snapshot.sh -r -j project2 -f labels.backup=true
```