### PR TITLE
Fixing --filter clause on disk name

### DIFF
--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -181,9 +181,9 @@ getDeviceList()
     else
         # check if $FILTER_CLAUSE exists
         if [[ ! -z $FILTER_CLAUSE ]]; then
-            filter="name:$1 AND ${FILTER_CLAUSE}"
+            filter="users~instances/$1\$ AND ${FILTER_CLAUSE}"
         else
-            filter="name:$1"
+            filter="users~instances/$1\$"
         fi
     fi
 


### PR DESCRIPTION
Previously was only picking up disks with same name as instance (#77)