### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM google/cloud-sdk
+RUN apt-get -y install curl
+ADD gcloud-snapshot.sh /opt/gcloud-snapshot.sh
+ADD entrypoint.sh /opt/entrypoint.sh
+RUN chmod u+x /opt/gcloud-snapshot.sh /opt/entrypoint.sh
+ENTRYPOINT /opt/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Options:
           create / delete commands [OPTIONAL]
 ```
 
+## Docker Support
+
+This project has a `Dockerfile` and can therefore be run as a container in a VM, or in a Kubernetes cluster.
+In this context, it will be run with the `-r` option to back up all disks the container has access to. The
+intended usage is to run the container periodically as a Kubernetes cron task.
+
+However it is also possible to set the environment variables `DAEMON` which will make the container run
+continually and take snapshots at intervals. By default the interval is 21600 seconds (6 hours) but can
+be overridden by setting the environment variable `SLEEP`.
+
+You set environment variable `FILTER` to set a filter condition as documented in
+[Matching on specific disks](#matching-on-specific-disks). Otherwise all disks are snapshotted.
+
+At the time of writing, this image is available on [Docker Hub](https://hub.docker.com/r/djjudas21/google-compute-snapshot/)
+as `djjudas21/google-compute-snapshot`.
+
 ## Usage Examples
 
 ### Snapshot Retention

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# run gcloud-snapshot.sh once and execute the notify
+# Alternative if $DAEMON is set, run it in a loop with a configurable delay
+# ($SLEEP environment variable) and a notification command 
+# ($NOTIFY_COMMAND environment variable), for example a curl webhook
+# notification (e.g. to Slack).
+run() {
+	if [ -n "${FILTER}" ]; then
+		/opt/gcloud-snapshot.sh -r -f "$FILTER"
+	else
+		/opt/gcloud-snapshot.sh -r
+	fi
+	if [ -n "${NOTIFY_COMMAND}" ]; then
+		echo "Running notify command: $NOTIFY_COMMAND"
+		bash -c "$NOTIFY_COMMAND"
+	fi
+}
+
+if [ -n "${DAEMON}" ]; then
+	if [ -z "${SLEEP}" ]; then
+		# Default to every 6 hours
+		SLEEP=21600
+	fi
+	while true; do
+		run
+		echo "Sleeping for $SLEEP seconds"
+		sleep $SLEEP
+	done
+else
+	run
+fi


### PR DESCRIPTION
Add a `Dockerfile` and an `entrypoint.sh` to enable this to run inside a Docker container.

This has been tested and I am already using it after installing into Kubernetes via Helm:

```yaml
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: google-compute-snapshot
spec:
  schedule: "05 16 * * *"
  jobTemplate:
    spec:
      template:
        spec:
          restartPolicy: OnFailure
          containers:
          - name: google-compute-snapshot
            image: djjudas21/google-compute-snapshot:docker_support
            imagePullPolicy: Always
            env:
            - name: "FILTER"
              value: "labels.auto_snapshot=true"
```

And this produces output like:

```
$ kubectl get all
NAME                                           READY   STATUS             RESTARTS   AGE
pod/google-compute-snapshot-1544544300-tnxvb   0/1     Completed          0          3m40s

NAME                                           COMPLETIONS   DURATION   AGE
job.batch/google-compute-snapshot-1544544300   1/1           23s        3m41s

NAME                                    SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/google-compute-snapshot   05 16 * * *   False     1        3m45s           154m
```

At the moment the Docker image is automagically built via [Docker Hub automated builds](https://hub.docker.com/r/djjudas21/google-compute-snapshot/) from my Github fork of this project. As part of this PR, please would you consider also setting up automated builds from your repo? I'm happy to explain this if you're not sure.