### PR TITLE
Match prefix at only the start of the string.

### DIFF
--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -398,7 +398,7 @@ main()
         local snapshot_name=$(createSnapshotName ${PREFIX} ${device_name} ${DATE_TIME})
 
         # delete snapshots for this disk that were created older than DELETION_DATE
-        deleteSnapshots "$PREFIX-.*" "$DELETION_DATE" "${device_id}"
+        deleteSnapshots "^$PREFIX-.*" "$DELETION_DATE" "${device_id}"
 
         # create the snapshot
         createSnapshot ${device_name} ${snapshot_name} ${device_zone}


### PR DESCRIPTION
Hello @jacksegal!

Thanks for this script, it is great.

I found a small bug, where snapshots are being deleted that are not supposed to be:

I set the prefix to `backup` and have a few snapshots that have `backup` in the name (`test-backup-snapshot`) that were not created with this script. When I ran the script, it deleted the snapshots that were not prefixed with `backup`. This PR prevents deleting snapshots that have the prefix name in them.

Log from run where snapshot was deleted:
```
[2019-03-01 15:50:49]: Handling Snapshots for my-awesome-instance
Deleted [https://www.googleapis.com/compute/v1/projects/<PROJECT>/global/snapshots/test-backup-snapshotl].
Creating snapshot(s) backup-foo-bar...
```

