### PR TITLE
Enable guest-flush for windows instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options:
     -r    Backup remote instances - takes snapshots of all disks calling instance has
           access to [OPTIONAL].
     -f    gcloud filter expression to query disk selection [OPTIONAL]
+    -g    Guest Flush (VSS only for Windows VMs) [OPTIONAL]
     -c    Copy disk labels to snapshot labels [OPTIONAL]
     -p    Prefix to be used for naming snapshots.
           Max character length: 20
@@ -154,6 +155,18 @@ Using Labels: You could add a label of `auto_snapshot=true` to all disks that yo
 Backup specific zone: If you wanted to only backup disks in a specific zone you could run:
 
     ./gcloud-compute-snapshot.sh -f "zone: us-central1-c"
+
+### Guest Flush (VSS for Windows)
+Google supports Guest Flush (Volume Shadow Copy quiesce) for Windows Instances's. See [Googles Documentation](https://cloud.google.com/compute/docs/instances/windows/creating-windows-persistent-disk-snapshot#create-snapshot) for limitations. It's recommended that it's only used for secondary data disks, and not for boot volumes.
+
+It will only work with a Windows Instance, and will not work with Linux instances. If you attempt it on an instance that doesn't support guest flush, the snapshot WILL fail.
+
+    Usage: ./gcloud-snapshot.sh [-g]
+
+    Options:
+
+       -g  Guest Flush (VSS only for Windows VMs) [OPTIONAL]
+
 
 ### Copy Disk Labels to Snapshots
 Disks can have labels, but snapshots don't automatically get the same labels. To copy labels from source disk to the snapshots use the -c flag. This can be useful if you wish to filter snapshots based on the original disks labels:

--- a/gcloud-snapshot.sh
+++ b/gcloud-snapshot.sh
@@ -27,6 +27,7 @@ usage() {
     echo -e "    -r    Backup remote instances - takes snapshots of all disks calling instance has"
     echo -e "          access to [OPTIONAL]."
     echo -e "    -f    gcloud filter expression to query disk selection [OPTIONAL]"
+    echo -e "    -g    Guest Flush (VSS only for Windows VMs) [OPTIONAL]"
     echo -e "    -c    Copy disk labels to snapshot labels [OPTIONAL]"
     echo -e "    -p    Prefix to be used for naming snapshots."
     echo -e "          Max character length: 20"
@@ -50,7 +51,7 @@ usage() {
 
 setScriptOptions()
 {
-    while getopts ":d:rf:cp:a:j:l:n" opt; do
+    while getopts ":d:rf:gcp:a:j:l:n" opt; do
         case $opt in
             d)
                 opt_d=${OPTARG}
@@ -60,6 +61,9 @@ setScriptOptions()
                 ;;
             f)
                 opt_f=${OPTARG}
+                ;;
+            g)
+                opt_g=true
                 ;;
             c)
                 opt_c=true
@@ -139,6 +143,13 @@ setScriptOptions()
     # Copy Disk Labels to Snapshots
     if [[ -n $opt_c ]]; then
         COPY_LABELS=$opt_c
+    fi
+
+    # Guest Flush (VSS for Windows)
+    if [[ -n $opt_c ]]; then
+        OPT_GUEST_FLUSH="--guest-flush"
+    else
+        OPT_GUEST_FLUSH=""
     fi
 
     # Snapshot storage location
@@ -258,9 +269,9 @@ createSnapshotName()
 createSnapshot()
 {
     if [ "$DRY_RUN" = true ]; then
-        printCmd "gcloud ${OPT_ACCOUNT} compute disks snapshot $1 --snapshot-names $2 --zone $3 ${OPT_PROJECT} ${OPT_SNAPSHOT_LOCATION}"
+        printCmd "gcloud ${OPT_ACCOUNT} compute disks snapshot $1 --snapshot-names $2 --zone $3 ${OPT_PROJECT} ${OPT_SNAPSHOT_LOCATION} ${OPT_GUEST_FLUSH}"
     else
-        $(gcloud $OPT_ACCOUNT compute disks snapshot $1 --snapshot-names $2 --zone $3 ${OPT_PROJECT} ${OPT_SNAPSHOT_LOCATION})
+        $(gcloud $OPT_ACCOUNT compute disks snapshot $1 --snapshot-names $2 --zone $3 ${OPT_PROJECT} ${OPT_SNAPSHOT_LOCATION} ${OPT_GUEST_FLUSH})
     fi
 }
 


### PR DESCRIPTION
Guest Flush only works with windows instances at the moment, so if someone is using this feature they need to filter the disks appropriately.

This allows us to "flush" (VSS) our windows data disks before the snapshot is taken, for a consistent snapshot.